### PR TITLE
feat: add .close()

### DIFF
--- a/test.js
+++ b/test.js
@@ -81,4 +81,21 @@ describe('nsq-relayer', () =>
 		};
 		r.handleEvent(msg);
 	});
+
+	it('exposes close()', function(done)
+	{
+		const r = createRelayer();
+		var count = 0;
+		r.nsq.close = function()
+		{
+			count++;
+		};
+
+		const eventCount = process.listeners('nsq').length;
+		r.close();
+		(process.listeners('nsq').length - eventCount).must.equal(-1);
+		count.must.equal(1);
+		done();
+	});
+
 });


### PR DESCRIPTION
- This adds a method to close the nsq client and remove the listener.
- I've turned the opt-parsing into destructuring, mostly because our
  underlying dep (squeaky) opts us into node 6+ by using that feature.

This ends up being useful for tests & hot reloading servers: in those cases it's handy to be able to shut down the relayer cleanly.