### PR TITLE
fix: use .hostname to omit port; pass port explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# numbat-nsq
+# nsq-relayer
 
 You emit events structured in a specific way and this tool posts them all to its configured nsq instance.
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ class NSQRelayer
 	constructor({ nsq = 'http://localhost:4150', topic = 'relayed', event = 'nsq' })
 	{
 		const parsed = url.parse(nsq);
-		this.nsq = new Squeaky({ host: parsed.host });
+		this.nsq = new Squeaky({ host: parsed.hostname, port: parsed.port || 4150 });
 		this.topic = topic;
 		this.eventName = event;
 		this.logger = bole(event);


### PR DESCRIPTION
Use `hostname` instead of `host` to omit `port`, since squeaky is expecting args suitable for passing to `net.connect`, and API consistency in Node is A Thing.