### PR TITLE
feature: you can now relay to a list of topics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+- '8'
+script:
+  - npm run test:travis

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ You emit events structured in a specific way and this tool posts them all to its
 const createRelayer = require('nsq-relayer');
 
 const relayer = createRelayer({
-	topic: 'foozle',
-	nsq: 'http://localhost:5141',
+	nsq: 'http://localhost:4151',
 	event: 'event-to-listen-for'
+	topic: 'foozle',
 });
 
 // later on
@@ -16,15 +16,29 @@ process.emit('event-to-listen-for', { name: 'my-little-message', type: 'cutie-ma
 // the relayer will then post this to nsq for us with zero effort
 ```
 
-## Configuration
+You can also pass an array of names to relay to more than one nsq topic. In this case, the nsq topic is the same as the event.
 
-TBD.
+```js
+const relayer = createRelayer({
+	nsq: 'http://localhost:4151',
+	relays: [ 'metric', 'email', 'cute-kitten' ],
+});
+
+// relay to `metric` nsq topic
+process.emit('metric', { name: 'pony-count', value: 200 });
+// relay to `email` nsq topic
+process.emit('email', { to: 'friendship@example.com', subject: 'this example is long' });
+// relay to `cute-kitten` nsq topic
+process.emit('cute-kitten', { name: 'Mittens', color: 'orange tabby' });
+```
+
+For both configuration styles, the `nsq` field is a uri-formatted string. The host & port will be parsed out & passed to [squeaky](https://github.com/nlf/squeaky).
 
 ## Notes
 
 No attempt is made to retry failed event posts.
 
-Each event is posted as it arrives, without batching. You might want to batch if you're posting many events per second.
+Each event is posted as it arrives, without batching. You might want to batch if you're posting many events per second. Or use the TCP mode for squeaky, which opens a connection, keeps it open, and shoves data through.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # nsq-relayer
 
-You emit events structured in a specific way and this tool posts them all to its configured nsq instance.
+[![Build Status](https://travis-ci.org/ceejbot/nsq-relayer.svg?branch=master)](https://travis-ci.org/ceejbot/nsq-relayer)
+
+You emit events from anywhere in your code and this module posts them all to its configured nsq instance.
 
 ```js
 const createRelayer = require('nsq-relayer');

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,12 @@
         "samsam": "1.3.0"
       }
     },
+    "@std/esm": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@std/esm/-/esm-0.23.4.tgz",
+      "integrity": "sha512-S+gN8dIuCmNn84Maa2DNBhJK38hQh/0Fm1c6Njc2YBjE+xpnj039T8jSZpyv74pvbjoZdaGAJNP/uhVqaf+uTw==",
+      "dev": true
+    },
     "acorn": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
@@ -354,9 +360,9 @@
       }
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "buf-compare": {
@@ -990,9 +996,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "dir-glob": {
@@ -2908,15 +2914,15 @@
       }
     },
     "mocha": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.1.tgz",
-      "integrity": "sha512-SpwyojlnE/WRBNGtvJSNfllfm5PqEDFxcWluSIgLeSBJtXG4DmoX2NNAeEA7rP5kK+79VgtVq8nG6HskaL1ykg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.4.tgz",
+      "integrity": "sha512-nMOpAPFosU1B4Ix1jdhx5e3q7XO55ic5a8cgYvW27CequcEY+BabS0kUVL1Cw1V5PuVHZWeNRWFLmEPexo79VA==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
+        "browser-stdout": "1.3.1",
         "commander": "2.11.0",
         "debug": "3.1.0",
-        "diff": "3.3.1",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
         "growl": "1.10.3",
@@ -3020,9 +3026,9 @@
       "dev": true
     },
     "nise": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.5.tgz",
-      "integrity": "sha512-Es4hGuq3lpip5PckrB+Qpuma282M0UJANJ+jxAgI+0wWTL9X6MtNv+M385JgqsAE8hv6NvD3lv8CQtXgEnvlpQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
+      "integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
@@ -5593,17 +5599,18 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.3.0.tgz",
-      "integrity": "sha512-pmf05hFgEZUS52AGJcsVjOjqAyJW2yo14cOwVYvzCyw7+inv06YXkLyW75WG6X6p951lzkoKh51L2sNbR9CDvw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.3.tgz",
+      "integrity": "sha512-pwvXHQbLuZR2GPylhm7JII9lCYqLxwpixCqKDELWyrmqRKlNgAxslWTVVbm2EOu4vSQ3cY/Lc0IF0d36OJTLcg==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
-        "diff": "3.3.1",
+        "@std/esm": "0.23.4",
+        "diff": "3.5.0",
         "lodash.get": "4.4.2",
         "lolex": "2.3.2",
-        "nise": "1.2.5",
-        "supports-color": "5.2.0",
+        "nise": "1.3.0",
+        "supports-color": "5.3.0",
         "type-detect": "4.0.8"
       },
       "dependencies": {
@@ -5614,9 +5621,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -5874,9 +5881,9 @@
       "dev": true
     },
     "squeaky": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/squeaky/-/squeaky-1.4.0.tgz",
-      "integrity": "sha512-J85li3nXmP/CyHmINdx6OZ0DFkK3W+qy5QK5Ar5/ce68PGqFgmg0iWy9/3KoYrYQfSFUOTChx1cCGsKKMNMjFg=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/squeaky/-/squeaky-1.4.1.tgz",
+      "integrity": "sha512-wENBlJHhR00LqVFV4ODKmRJKD93hlDQEFQIEUPn1+vxhqZfrteH2427d4p4neViwNGEk5NYSgu3Tei89x0bP+g=="
     },
     "sshpk": {
       "version": "1.13.1",

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
   },
   "dependencies": {
     "bole": "~3.0.2",
-    "squeaky": "~1.4.0"
+    "squeaky": "~1.4.1"
   },
   "devDependencies": {
     "coveralls": "~3.0.0",
     "eslint-config-ceejbot": "~1.1.0",
-    "mocha": "~5.0.1",
+    "mocha": "~5.0.4",
     "must": "~0.13.4",
     "nyc": "~11.4.1",
-    "sinon": "~4.3.0",
+    "sinon": "~4.4.3",
     "xo": "~0.20.3"
   },
   "homepage": "https://github.com/ceejbot/nsq-relayer#readme",
@@ -30,15 +30,17 @@
     "url": "git+https://github.com/ceejbot/nsq-relayer.git"
   },
   "scripts": {
-    "test": "mocha -R spec",
-    "test:cov": "nyc mocha -R spec",
+    "test": "mocha -R spec --exit",
+    "test:cov": "nyc mocha -R spec --exit",
     "test:style": "xo",
     "test:travis": "npm run test:cov && npm run test:style"
   },
   "xo": {
     "extends": "eslint-config-ceejbot",
     "rules": {
-      "prefer-arrow-callback": 0
+      "prefer-arrow-callback": 0,
+      "semi-style": 0,
+      "unicorn/import-index": 0
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -40,7 +40,7 @@ describe('nsq-relayer', () =>
 	it('listens for the configured event', function(done)
 	{
 		const r = createRelayer();
-		r.handleEvent = function fn(topic, msg)
+		r.handleEvent = function handleEvent(topic, msg)
 		{
 			msg.must.be.an.object();
 			msg.payload.must.equal('hello world');
@@ -72,7 +72,7 @@ describe('nsq-relayer', () =>
 		r.events.must.be.an.object();
 		Object.keys(r.events).length.must.equal(relays.length);
 
-		r.handleEvent = function fn(topic, msg)
+		r.handleEvent = function handleEvent(topic, msg)
 		{
 			topic.must.equal(msg);
 		};
@@ -91,7 +91,6 @@ describe('nsq-relayer', () =>
 			return Promise.reject(new Error('wat'));
 		};
 		const msg = { payload: 'hello world'};
-		var count = 0;
 
 		r.logger.warn = function(logline)
 		{


### PR DESCRIPTION
You can now set up an array of nsq relays, with the restriction that the event name must be the same as the nsq topic being posted to. The following code snippet sets up relays to three different nsq topics:

```js
const relayer = createRelayer({
   nsq: 'http://localhost:4151',
   relays: [ 'metric', 'email', 'cute-kitten' ],
});
```

Added tests for the new option and for the listener cleanup.
Documented the new option in the readme.
Test coverage is now missing one line (the success debug log).